### PR TITLE
Fetch terror zones from webpage and show upcoming rotation

### DIFF
--- a/src/services/d2_api.py
+++ b/src/services/d2_api.py
@@ -1,40 +1,44 @@
 from __future__ import annotations
 
-import asyncio
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import List, Optional, Tuple
 
 import httpx
 
-from utils.config import get_settings, Settings
+from utils.config import Settings, get_settings
 
 
 # ---------------------------- Public datatypes ---------------------------------
 
+
 @dataclass(frozen=True)
 class TerrorZone:
     name: str
-    act: Optional[str] = None
-    code: Optional[str] = None
 
 
 class D2ApiError(RuntimeError):
-    """Network or server-side error when contacting the D2 API."""
+    """Network or server-side error when contacting the terror zone source."""
 
 
 class D2ParseError(RuntimeError):
-    """Response JSON structure doesn't contain a recognizable terror zone."""
+    """Unable to parse terror zone information from the source page."""
 
 
 # ---------------------------- Client implementation ----------------------------
 
+
 class D2ApiClient:
-    def __init__(self, settings: Optional[Settings] = None, *, client: Optional[httpx.AsyncClient] = None) -> None:
+    def __init__(
+        self,
+        settings: Optional[Settings] = None,
+        *,
+        client: Optional[httpx.AsyncClient] = None,
+    ) -> None:
         self._settings = settings or get_settings()
         self._own_client = client is None
         self._client = client or httpx.AsyncClient(
             timeout=self._settings.http_timeout_seconds,
-            headers=self._build_headers(),
+            headers={"User-Agent": "diablo-terror-bot/1.0 (+telegram)"},
         )
 
     # -------- lifecycle --------
@@ -51,110 +55,56 @@ class D2ApiClient:
 
     # -------- public API --------
 
-    async def get_current_terror_zone(self) -> TerrorZone:
+    async def get_current_and_next_zones(self) -> Tuple[TerrorZone, TerrorZone]:
+        """Fetch the current and upcoming terror zones."""
+
         url = self._settings.d2_api_url
-        token = self._settings.d2_api_token
+        try:
+            resp = await self._client.get(url)
+            resp.raise_for_status()
+        except httpx.HTTPError as e:
+            raise D2ApiError(f"HTTP error contacting terror zone source: {e}") from e
 
-        last_err: Optional[Exception] = None
-        retries = max(0, int(self._settings.http_retries))
+        html = resp.text
+        try:
+            current_names = self._extract_names(html, "a2x")
+            next_names = self._extract_names(html, "x2a")
+            current = TerrorZone(name=self._compose_name(current_names))
+            nxt = TerrorZone(name=self._compose_name(next_names))
+            return current, nxt
+        except Exception as e:
+            raise D2ParseError(f"Unable to parse terror zone HTML: {e}") from e
 
-        for attempt in range(retries + 1):
-            try:
-                resp = await self._client.get(url, params={"token": token})
-                # Retry on certain status codes
-                if resp.status_code >= 500 or resp.status_code == 429:
-                    raise D2ApiError(f"Upstream returned HTTP {resp.status_code}")
-
-                resp.raise_for_status()
-                data = resp.json()
-                tz = self._extract_current(data)
-                if tz is None or not tz.name:
-                    raise D2ParseError(
-                        f"Missing terror zone name in response JSON. Top-level keys: {list(data) if isinstance(data, dict) else type(data)}"
-                    )
-                return tz
-
-            except (httpx.TimeoutException, httpx.TransportError, D2ApiError) as e:
-                last_err = e
-                if attempt < retries:
-                    await asyncio.sleep(self._backoff_delay(attempt))
-                else:
-                    raise D2ApiError(f"D2 API request failed after {attempt+1} attempts: {e}") from e
-            except (ValueError, D2ParseError) as e:
-                raise D2ParseError(f"Unable to parse D2 API response: {e}") from e
-
-        raise D2ApiError(f"D2 API request failed: {last_err}")
+    async def get_current_terror_zone(self) -> TerrorZone:
+        current, _ = await self.get_current_and_next_zones()
+        return current
 
     # -------- internals --------
 
-    def _build_headers(self) -> dict[str, str]:
-        headers = {
-            "User-Agent": "diablo-terror-bot/1.0 (+telegram)",
-            "Accept": "application/json",
-        }
-        headers.update(self._settings.d2_request_headers())
-        return headers
+    @staticmethod
+    def _extract_names(html: str, div_id: str) -> List[str]:
+        import re
+
+        pattern = rf'<div id="{div_id}">(.*?)</div>'
+        match = re.search(pattern, html, flags=re.IGNORECASE | re.DOTALL)
+        if not match:
+            raise ValueError(f"div #{div_id} not found")
+        block = match.group(1)
+        return [p.strip() for p in block.split("<br>") if p.strip()]
 
     @staticmethod
-    def _get_str(d: Any, *path: str) -> Optional[str]:
-        cur = d
-        for key in path:
-            if not isinstance(cur, dict):
-                return None
-            cur = cur.get(key)
-        if isinstance(cur, str):
-            s = cur.strip()
-            return s if s else None
-        return None
-
-    @staticmethod
-    def _extract_current(payload: Any) -> Optional[TerrorZone]:
-        if not isinstance(payload, dict):
-            return None
-
-        name = D2ApiClient._get_str(payload, "currentTerrorZone", "zone")
-        if name:
-            act = D2ApiClient._get_str(payload, "currentTerrorZone", "act")
-            return TerrorZone(name=name, act=act)
-
-        name = D2ApiClient._get_str(payload, "terrorZone", "reportedZones", "zone")
-        if name:
-            act = D2ApiClient._get_str(payload, "terrorZone", "reportedZones", "act") or D2ApiClient._get_str(payload, "terrorZone", "act")
-            return TerrorZone(name=name, act=act)
-
-        name = D2ApiClient._get_str(payload, "terrorZone", "zone")
-        if name and name.lower() != "unknown":
-            act = D2ApiClient._get_str(payload, "terrorZone", "act")
-            return TerrorZone(name=name, act=act)
-
-        name = D2ApiClient._get_str(payload, "current_terror_zone", "zone")
-        if name:
-            act = D2ApiClient._get_str(payload, "current_terror_zone", "act")
-            return TerrorZone(name=name, act=act)
-
-        name = D2ApiClient._get_str(payload, "terror_zone", "reported_zones", "zone")
-        if name:
-            act = D2ApiClient._get_str(payload, "terror_zone", "reported_zones", "act") or D2ApiClient._get_str(payload, "terror_zone", "act")
-            return TerrorZone(name=name, act=act)
-
-        name = D2ApiClient._get_str(payload, "terror_zone", "zone")
-        if name:
-            act = D2ApiClient._get_str(payload, "terror_zone", "act")
-            return TerrorZone(name=name, act=act)
-
-        name = D2ApiClient._get_str(payload, "zone")
-        if name:
-            return TerrorZone(name=name)
-
-        return None
-
-    @staticmethod
-    def _backoff_delay(attempt: int) -> float:
-        base = 0.5 * (2 ** attempt)
-        return base + 0.05 * attempt
+    def _compose_name(parts: List[str]) -> str:
+        if not parts:
+            return ""
+        if len(parts) == 1:
+            return parts[0]
+        if len(parts) == 2:
+            return f"{parts[0]} and {parts[1]}"
+        return ", ".join(parts[:-1]) + f", and {parts[-1]}"
 
 
 # ---------------------------- Convenience factory ------------------------------
+
 
 def build_client(settings: Optional[Settings] = None) -> D2ApiClient:
     return D2ApiClient(settings=settings)

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -50,11 +50,7 @@ def _env_bool(key: str, default: Optional[bool] = None) -> Optional[bool]:
 class Settings:
     bot_token: str
 
-    d2_api_token: str
-    d2_api_url: str = "https://d2runewizard.com/api/terror-zone"
-    d2_api_contact: Optional[str] = None
-    d2_api_platform: Optional[str] = "Telegram"
-    d2_api_repo: Optional[str] = None
+    d2_api_url: str = "https://d2emu.com/tz"
 
     db_dsn: Optional[str] = None
     db_host: str = "localhost"
@@ -66,7 +62,6 @@ class Settings:
     notify_interval_seconds: int = 3600
     notify_align_minute: int = 2
     http_timeout_seconds: int = 10
-    http_retries: int = 2
 
     default_language: str = "ru"
     supported_languages: tuple[str, ...] = ("ru",)
@@ -84,28 +79,13 @@ class Settings:
         name = self.db_name
         return f"postgresql://{user}:{pw}@{host}:{port}/{name}"
 
-    def d2_request_headers(self) -> dict[str, str]:
-        headers: dict[str, str] = {}
-        if self.d2_api_contact:
-            headers["D2R-Contact"] = self.d2_api_contact
-        if self.d2_api_platform:
-            headers["D2R-Platform"] = self.d2_api_platform
-        if self.d2_api_repo:
-            headers["D2R-Repo"] = self.d2_api_repo
-        return headers
-
-
 @lru_cache(maxsize=1)
 def get_settings() -> Settings:
     _maybe_load_dotenv()
 
     bot_token = _env_str("BOT_TOKEN", required=True)
-    d2_api_token = _env_str("D2_API_TOKEN", required=True)
 
-    d2_api_url = _env_str("D2_API_URL", default="https://d2runewizard.com/api/terror-zone")
-    d2_api_contact = _env_str("D2_API_CONTACT", default=None)
-    d2_api_platform = _env_str("D2_API_PLATFORM", default="Telegram")
-    d2_api_repo = _env_str("D2_API_REPO", default=None)
+    d2_api_url = _env_str("D2_API_URL", default="https://d2emu.com/tz")
 
     db_dsn = _env_str("DB_DSN", default=None)
     db_host = _env_str("DB_HOST", default="localhost") or "localhost"
@@ -117,7 +97,6 @@ def get_settings() -> Settings:
     notify_interval_seconds = _env_int("NOTIFY_INTERVAL_SECONDS", default=3600) or 3600
     notify_align_minute = _env_int("NOTIFY_ALIGN_MINUTE", default=2) or 2
     http_timeout_seconds = _env_int("HTTP_TIMEOUT_SECONDS", default=10) or 10
-    http_retries = _env_int("HTTP_RETRIES", default=2) or 2
 
     default_language = _env_str("DEFAULT_LANGUAGE", default="ru") or "ru"
     supported_languages_raw = _env_str("SUPPORTED_LANGUAGES", default="ru") or "ru"
@@ -129,11 +108,7 @@ def get_settings() -> Settings:
 
     return Settings(
         bot_token=bot_token,
-        d2_api_token=d2_api_token,
-        d2_api_url=d2_api_url or "https://d2runewizard.com/api/terror-zone",
-        d2_api_contact=d2_api_contact,
-        d2_api_platform=d2_api_platform,
-        d2_api_repo=d2_api_repo,
+        d2_api_url=d2_api_url or "https://d2emu.com/tz",
         db_dsn=db_dsn,
         db_host=db_host,
         db_port=db_port,
@@ -143,7 +118,6 @@ def get_settings() -> Settings:
         notify_interval_seconds=notify_interval_seconds,
         notify_align_minute=notify_align_minute,
         http_timeout_seconds=http_timeout_seconds,
-        http_retries=http_retries,
         default_language=default_language,
         supported_languages=supported_languages,
         log_level=log_level,


### PR DESCRIPTION
## Summary
- scrape current and next terror zones from d2emu.com instead of API
- simplify settings to use the webpage URL without API token or retries
- show both current and next zones in bot commands and menu

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aac801069c8329b3c8c44d971ee0f2